### PR TITLE
Update README.md links to Khronos deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 glTF 2.0 Reference Viewer
 =========================
 
-[![](assets/images/BoomBox.jpg)](http://gltf.ux3d.io/)
+[![](assets/images/BoomBox.jpg)](http://github.khronos.org/glTF-Sample-Viewer/)
 
 This is the offical [Khronos](https://www.khronos.org/) [glTF 2.0](https://www.khronos.org/gltf/) reference viewer using [WebGL](https://www.khronos.org/webgl/).
 
@@ -28,7 +28,7 @@ Viewer
 Usage
 -----
 
-If you would like to see this in action, [view the live demo](http://gltf.ux3d.io/).
+If you would like to see this in action, [view the live demo](http://github.khronos.org/glTF-Sample-Viewer/).
 
 **Controls**
 
@@ -94,12 +94,6 @@ Debugging
 * Install the [Debugger for Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug) extension for Visual Studio Code
 * Open the project folder in Visual Studio Code and select `Debug->Add Configuration->Firefox` so the `.vscode/launch.json` file is created.
 * `Debug->Start Debugging` should now launch a Firefox window with the reference viewer and VS Code breakpoints should be hit.
-
-**VS Code**
-
-Modified VSCode gltf-vscode plugin:
-
-[gltf-vscode](https://github.com/ux3d/gltf-vscode/tree/features/khronosRV-setup)
 
 
 Physically-Based Materials in glTF 2.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 glTF 2.0 Reference Viewer
 =========================
 
-[![](assets/images/BoomBox.jpg)](http://github.khronos.org/glTF-Sample-Viewer/)
+[![](assets/images/BoomBox.jpg)](https://github.khronos.org/glTF-Sample-Viewer/)
 
 This is the offical [Khronos](https://www.khronos.org/) [glTF 2.0](https://www.khronos.org/gltf/) reference viewer using [WebGL](https://www.khronos.org/webgl/).
 
@@ -28,7 +28,7 @@ Viewer
 Usage
 -----
 
-If you would like to see this in action, [view the live demo](http://github.khronos.org/glTF-Sample-Viewer/).
+If you would like to see this in action, [view the live demo](https://github.khronos.org/glTF-Sample-Viewer/).
 
 **Controls**
 


### PR DESCRIPTION
This makes use of the Khronos-hosted GitHub Pages version of the site.

Also, remove reference to fork of gltf-vscode.  Would be great to get those changes into a PR and merged into the published version of VSCode, but advertising a non-standard fork of the project is not the correct way to do that.