### PR TITLE
Add Yarn lock file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 package-lock.json
 dist
 .idea
+yarn.lock


### PR DESCRIPTION
This PR adds a `yarn.lock` entry to `.gitignore`. [Yarn](https://yarnpkg.com/en/) is a popular alternative dependency manager for NPM which automatically writes a `yarn.lock` file upon installing.

Kind regards,

Tim