### PR TITLE
Move f0_ior to an app-level computation.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,10 @@
         "**/Thumbs.db": true,
         "node_modules": true
     },
+    "search.exclude": {
+        "**/node_modules": true,
+        "assets/models/1.0": true
+    },
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "editor.insertSpaces": true,

--- a/src/material.js
+++ b/src/material.js
@@ -541,9 +541,15 @@ class gltfMaterial extends GltfObject
                     ior = 1.0;
                 }
 
+                // Compute the achromatic normal incidence reflectance based on a given index of refraction of a dielectric material.
+                // The index of refraction of the surrounding is assumed to be 1.0, which is approximatly the case for air.
+                // For an index of refraction of 1.5, this results the known default value of 0.04 reflectivity for dielectrics.
+                let f0_ior = (ior - 1.0) / (ior + 1.0);
+                f0_ior *= f0_ior;
+
                 this.defines.push("MATERIAL_IOR 1");
 
-                this.properties.set("u_IOR", ior);
+                this.properties.set("u_IOR_and_f0", jsToGl([ior, f0_ior]));
             }
 
             // KHR Extension: Absorption

--- a/src/shaders/brdf.glsl
+++ b/src/shaders/brdf.glsl
@@ -1,13 +1,3 @@
-
-// Compute the achromatic normal incidence reflectance based on a given index of refraction of a dielectric material.
-// The index of refraction of the surrounding is assumed to be 1.0, which is approximatly the case for air.
-// For an index of refraction of 1.5, this results the known default value of 0.04 reflectivity for dielectrics.
-float f0_ior(float ior)
-{
-    float f0 = sq((ior - 1.0) / (ior + 1.0));
-    return f0;
-}
-
 //
 // Fresnel
 //

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -73,8 +73,8 @@ uniform float u_ThinFilmFactor;
 uniform float u_ThinFilmThicknessMinimum;
 uniform float u_ThinFilmThicknessMaximum;
 
-// IOR
-uniform float u_IOR;
+// IOR (in .x) and the corresponding f0 (in .y)
+uniform vec2 u_IOR_and_f0;
 
 // Thickness
 uniform float u_Thickness;
@@ -181,7 +181,7 @@ float getMetallicRoughnessSpecularFactor()
     return  0.08 * u_MetallicRoughnessSpecularFactor;
 }
 
-MaterialInfo getMetallicRoughnessInfo(MaterialInfo info, float ior)
+MaterialInfo getMetallicRoughnessInfo(MaterialInfo info, float f0_ior)
 {
     info.metallic = u_MetallicFactor;
     info.perceptualRoughness = u_RoughnessFactor;
@@ -199,7 +199,7 @@ MaterialInfo getMetallicRoughnessInfo(MaterialInfo info, float ior)
     vec3 f0 = vec3(getMetallicRoughnessSpecularFactor());
 #else
     // Achromatic f0 based on IOR.
-    vec3 f0 = vec3(f0_ior(ior));
+    vec3 f0 = vec3(f0_ior);
 #endif
 
     info.albedoColor = mix(info.baseColor.rgb * (vec3(1.0) - f0),  vec3(0), info.metallic);
@@ -397,10 +397,12 @@ void main()
 
 
 #ifdef MATERIAL_IOR
-    float ior = u_IOR;
+    float ior = u_IOR_and_f0.x;
+    float f0_ior = u_IOR_and_f0.y;
 #else
     // The default index of refraction of 1.5 yields a dielectric normal incidence reflectance of 0.04.
     float ior = 1.5;
+    float f0_ior = 0.04;
 #endif
 
 #ifdef MATERIAL_SPECULARGLOSSINESS
@@ -408,7 +410,7 @@ void main()
 #endif
 
 #ifdef MATERIAL_METALLICROUGHNESS
-    materialInfo = getMetallicRoughnessInfo(materialInfo, ior);
+    materialInfo = getMetallicRoughnessInfo(materialInfo, f0_ior);
 #endif
 
 #ifdef MATERIAL_SHEEN


### PR DESCRIPTION
This moves the calculation for `f0_ior` out of the fragment shader and up to the app level.

Also, glTF 1.0 assets are excluded from search results, because searching for GLSL code was hitting too many false positives there.
