### PR TITLE
Fixes type error for vec3 vertex color inside vertex shader.

### DIFF
--- a/src/shaders/functions.glsl
+++ b/src/shaders/functions.glsl
@@ -24,7 +24,7 @@ vec4 getVertexColor()
    vec4 color = vec4(1.0, 1.0, 1.0, 1.0);
 
 #ifdef HAS_VERTEX_COLOR_VEC3
-    color.rgb = v_Color;
+    color.rgb = v_Color.rgb;
 #endif
 #ifdef HAS_VERTEX_COLOR_VEC4
     color = v_Color;


### PR DESCRIPTION
When `HAS_VERTEX_COLOR_VEC3` is defined, the vertex shader produces a type error as `v_Color` is a `vec4` trying to be assigned to `color.rgb` which is a `vec3`.

I suspect this feature is not used often enough that it just slipped between the cracks.