### PR TITLE
Sample Viewer Enhancements: Fix bugs 

### DIFF
--- a/src/gltf_utils.js
+++ b/src/gltf_utils.js
@@ -67,22 +67,11 @@ function getExtendsFromAccessor(accessor, worldTransform, outMin, outMax)
 
     const radius = vec3.length(centerToSurface);
 
-    for (const i of [1, 2, 3])
+    for (const i of [0, 1, 2])
     {
         outMin[i] = center[i] - radius;
         outMax[i] = center[i] + radius;
     }
-}
-
-function getScaleFactor(gltf, sceneIndex)
-{
-    const min = vec3.create();
-    const max = vec3.create();
-    getSceneExtends(gltf, sceneIndex, min, max);
-    const minValue = Math.min(min[0], Math.min(min[1], min[2]));
-    const maxValue = Math.max(max[0], Math.max(max[1], max[2]));
-    const deltaValue = maxValue - minValue;
-    return 1.0 / deltaValue;
 }
 
 function computePrimitiveCentroids(gltf)
@@ -145,4 +134,4 @@ function computePrimitiveCentroids(gltf)
     }
 }
 
-export { getSceneExtends, getScaleFactor, computePrimitiveCentroids };
+export { getSceneExtends, computePrimitiveCentroids };

--- a/src/interpolator.js
+++ b/src/interpolator.js
@@ -27,6 +27,18 @@ class gltfInterpolator
         return quatResult;
     }
 
+    step(prevKey, output, stride)
+    {
+        const result = new glMatrix.ARRAY_TYPE(stride);
+
+        for(let i = 0; i < stride; ++i)
+        {
+            result[i] = output[prevKey * stride + i];
+        }
+
+        return result;
+    }
+
     linear(prevKey, nextKey, output, t, stride)
     {
         const result = new glMatrix.ARRAY_TYPE(stride);
@@ -122,10 +134,15 @@ class gltfInterpolator
                 quat.normalize(result, result);
                 return result;
             }
-            else {
+            else if(sampler.interpolation === InterpolationModes.LINEAR)
+            {
                 const q0 = this.getQuat(output, this.prevKey);
                 const q1 = this.getQuat(output, nextKey);
                 return this.slerpQuat(q0, q1, tn);
+            }
+            else if(sampler.interpolation === InterpolationModes.STEP)
+            {
+                return this.getQuat(output, this.prevKey);
             }
 
         }
@@ -133,7 +150,7 @@ class gltfInterpolator
         switch(sampler.interpolation)
         {
         case InterpolationModes.STEP:
-            return jsToGlSlice(output, this.prevKey * stride, stride); // t < 0.5 ? output[preKey] : output[nextKey]
+            return this.step(this.prevKey, output, stride);
         case InterpolationModes.CUBICSPLINE:
             return this.cubicSpline(this.prevKey, nextKey, output, keyDelta, tn, stride);
         default:

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -103,13 +103,13 @@ class gltfRenderer
 
         let currentCamera = undefined;
 
-        if(!this.parameters.userCameraActive())
+        if(this.parameters.userCameraActive())
         {
-            currentCamera = gltf.cameras[this.parameters.cameraIndex].clone();
+            currentCamera = this.defaultCamera;
         }
         else
         {
-            currentCamera = this.defaultCamera;
+            currentCamera = gltf.cameras[this.parameters.cameraIndex].clone();
         }
 
         currentCamera.aspectRatio = this.currentWidth / this.currentHeight;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -433,6 +433,9 @@ class gltfRenderer
         case(DebugOutput.NORMAL):
             fragDefines.push("DEBUG_NORMAL 1");
             break;
+        case(DebugOutput.WORLDSPACENORMAL):
+            fragDefines.push("DEBUG_WORLDSPACE_NORMAL 1");
+            break;
         case(DebugOutput.TANGENT):
             fragDefines.push("DEBUG_TANGENT 1");
             break;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -436,6 +436,9 @@ class gltfRenderer
         case(DebugOutput.WORLDSPACENORMAL):
             fragDefines.push("DEBUG_WORLDSPACE_NORMAL 1");
             break;
+        case(DebugOutput.GEOMETRYNORMAL):
+            fragDefines.push("DEBUG_GEOMETRY_NORMAL 1");
+            break;
         case(DebugOutput.TANGENT):
             fragDefines.push("DEBUG_TANGENT 1");
             break;

--- a/src/rendering_parameters.js
+++ b/src/rendering_parameters.js
@@ -49,6 +49,7 @@ const DebugOutput =
     METALLIC: "Metallic",
     ROUGHNESS: "Roughness",
     NORMAL: "Normal",
+    WORLDSPACENORMAL: "Worldspace Normal",
     TANGENT: "Tangent",
     BITANGENT: "Bitangent",
     BASECOLOR: "Base Color",

--- a/src/rendering_parameters.js
+++ b/src/rendering_parameters.js
@@ -50,6 +50,7 @@ const DebugOutput =
     ROUGHNESS: "Roughness",
     NORMAL: "Normal",
     WORLDSPACENORMAL: "Worldspace Normal",
+    GEOMETRYNORMAL: "Geometry Normal",
     TANGENT: "Tangent",
     BITANGENT: "Bitangent",
     BASECOLOR: "Base Color",

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -164,10 +164,12 @@ NormalInfo getNormalInfo(vec3 v)
     #endif
 
     // For a back-facing surface, the tangential basis vectors are negated.
-    float facing = step(0.0, dot(v, ng)) * 2.0 - 1.0;
-    t *= facing;
-    b *= facing;
-    ng *= facing;
+    if (gl_FrontFacing == false)
+    {
+        t *= -1.0;
+        b *= -1.0;
+        ng *= -1.0;
+    }
 
     // Due to anisoptry, the tangent can be further rotated around the geometric normal.
     vec3 direction;
@@ -684,8 +686,12 @@ void main()
         #endif
     #endif
 
+    #ifdef DEBUG_GEOMETRY_NORMAL
+        g_finalColor.rgb = (normalInfo.ng + 1.0) / 2.0;
+    #endif
+
     #ifdef DEBUG_WORLDSPACE_NORMAL
-            g_finalColor.rgb = (n + 1.0) / 2.0;
+        g_finalColor.rgb = (n + 1.0) / 2.0;
     #endif
 
     #ifdef DEBUG_TANGENT

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -684,6 +684,10 @@ void main()
         #endif
     #endif
 
+    #ifdef DEBUG_WORLDSPACE_NORMAL
+            g_finalColor.rgb = (n + 1.0) / 2.0;
+    #endif
+
     #ifdef DEBUG_TANGENT
         g_finalColor.rgb = t * 0.5 + vec3(0.5);
     #endif

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -537,6 +537,13 @@ void main()
     #endif
 #endif
 
+    float ao = 1.0;
+    // Apply optional PBR terms for additional (optional) shading
+#ifdef HAS_OCCLUSION_MAP
+    ao = texture(u_OcclusionSampler,  getOcclusionUV()).r;
+    f_diffuse = mix(f_diffuse, f_diffuse * ao, u_OcclusionStrength);
+#endif
+
 #ifdef USE_PUNCTUAL
     for (int i = 0; i < LIGHT_COUNT; ++i)
     {
@@ -644,13 +651,6 @@ void main()
     #endif
 
     color = (f_emissive + diffuse + f_specular + f_subsurface + (1.0 - reflectance) * f_sheen) * (1.0 - clearcoatFactor * clearcoatFresnel) + f_clearcoat * clearcoatFactor;
-
-    float ao = 1.0;
-    // Apply optional PBR terms for additional (optional) shading
-#ifdef HAS_OCCLUSION_MAP
-    ao = texture(u_OcclusionSampler,  getOcclusionUV()).r;
-    color = mix(color, color * ao, u_OcclusionStrength);
-#endif
 
 #ifndef DEBUG_OUTPUT // no debug
 

--- a/src/shaders/punctual.glsl
+++ b/src/shaders/punctual.glsl
@@ -27,7 +27,7 @@ float getRangeAttenuation(float range, float distance)
     if (range <= 0.0)
     {
         // negative range means unlimited
-        return 1.0;
+        return 1.0 / pow(distance, 2.0);
     }
     return max(min(1.0 - pow(distance / range, 4.0), 1.0), 0.0) / pow(distance, 2.0);
 }


### PR DESCRIPTION
Fix the following bugs
- Correct Application of Ambient Occlusion Map: fix https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/138
- Correct DEBUG_NORMAL output: fix https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/265
- Calculate animation sample STEP correctly: fix https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/269
- Correct brightness of KHR_lights_punctual lights: fix https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/275

Also fixes a bug where front facing normals were falsely interpreted as back facing and flipped even if the material was not double sided.