### PR TITLE
Update various links to official sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Khronos glTF 2.0 Sample Viewer
 ==============================
 
-[![](assets/images/ToyCar.jpg)](http://gltf.ux3d.io/)
+[![](assets/images/ToyCar.jpg)](https://github.khronos.org/glTF-Sample-Viewer-Release/)
 
-This is the official [Khronos](https://www.khronos.org/) [glTF 2.0](https://www.khronos.org/gltf/) Sample Viewer using [WebGL](https://www.khronos.org/webgl/): [glTF 2.0 Sample Viewer](http://gltf.ux3d.io/)
+This is the official [Khronos glTF 2.0](https://www.khronos.org/gltf/) Sample Viewer using [WebGL](https://www.khronos.org/webgl/): [glTF 2.0 Sample Viewer](https://github.khronos.org/glTF-Sample-Viewer-Release/)
 
 
 
@@ -71,7 +71,7 @@ glTF Sample Viewer can be used without the web app, for example for integration 
 
 The API consists of several components that in combination allow flexible configuration of the gltf viewer.
 
-More detailed information about the API is listed in the [api documentation](https://github.com/ux3d/glTF-Sample-Viewer/blob/develop/API.md).
+More detailed information about the API is listed in the [api documentation](API.md).
 
 ### GltfView
 
@@ -116,7 +116,7 @@ state.gltf = await resourceLoader.loadGltf("path/to/some.gltf");
 Web App
 -------
 
-You can find an example application for the gltf viewer in the [app_web subdirectory of the sample viewer repository](https://github.com/ux3d/glTF-Sample-Viewer/tree/develop/app_web). A live demo can be found at [gltf.ux3d.io](https://gltf.ux3d.io).
+You can find an example application for the gltf viewer in the [app_web subdirectory of the sample viewer repository](app_web). A live demo can be found at [https://github.khronos.org/glTF-Sample-Viewer-Release/](https://github.khronos.org/glTF-Sample-Viewer-Release/).
 
 **Running a local version**
 

--- a/app_web/README.md
+++ b/app_web/README.md
@@ -1,15 +1,15 @@
 glTF Sample Viewer Web App
 ==============================
 
-[![](../assets/images/BoomBox.jpg)](http://gltf.ux3d.io/)
+[![](../assets/images/BoomBox.jpg)](https://github.khronos.org/glTF-Sample-Viewer-Release/)
 
-This is the official [Khronos](https://www.khronos.org/) [glTF 2.0](https://www.khronos.org/gltf/) Sample Viewer using [WebGL](https://www.khronos.org/webgl/): [glTF 2.0 Sample Viewer](http://gltf.ux3d.io/)
+This is the official [Khronos glTF 2.0](https://www.khronos.org/gltf/) Sample Viewer using [WebGL](https://www.khronos.org/webgl/): [glTF 2.0 Sample Viewer](https://github.khronos.org/glTF-Sample-Viewer-Release/)
 
 
 Viewer
 ======
 
-Link to the live [glTF 2.0 Sample Viewer](http://gltf.ux3d.io/).
+Link to the live [glTF 2.0 Sample Viewer](https://github.khronos.org/glTF-Sample-Viewer-Release/).
 
 Usage
 -----

--- a/source/Renderer/shaders/pbr.frag
+++ b/source/Renderer/shaders/pbr.frag
@@ -12,7 +12,7 @@
 // [4] "An Inexpensive BRDF Model for Physically based Rendering" by Christophe Schlick
 //     https://www.cs.virginia.edu/~jdl/bib/appearance/analytic%20models/schlick94b.pdf
 // [5] "KHR_materials_clearcoat"
-//     https://github.com/ux3d/glTF/tree/KHR_materials_pbrClearcoat/extensions/2.0/Khronos/KHR_materials_clearcoat
+//     https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_clearcoat
 
 precision highp float;
 


### PR DESCRIPTION
UX3D is still prominently listed in the README's credits with a link to the main UX3D site as the primary developer.

Almost all other references to the UX3D intermediate development version have been updated to final Khronos links.