### PR TITLE
reload ktx lib as a workaround for an error from ktx lib

### DIFF
--- a/app_web/src/main.js
+++ b/app_web/src/main.js
@@ -41,6 +41,10 @@ async function main()
         mergeMap( (model) =>
         {
         	uiModel.goToLoadingState();
+
+            // Workaround for errors in ktx lib after loading an asset with ktx2 files for the second time:
+            resourceLoader.initKtxLib();
+
             return from(resourceLoader.loadGltf(model.mainFile, model.additionalFiles).then( (gltf) => {
                 state.gltf = gltf;
                 const defaultScene = state.gltf.scene;


### PR DESCRIPTION

1. drag and drop  [Avocado.zip](https://github.com/KhronosGroup/glTF-Sample-Viewer/files/6319257/Avocado.zip) into glTF viewer
2. drag and drop  [Avocado.zip](https://github.com/KhronosGroup/glTF-Sample-Viewer/files/6319257/Avocado.zip) into glTF viewer a second time

--> error message appears 
