### PR TITLE
Update HDRs

### DIFF
--- a/app_web/src/main.js
+++ b/app_web/src/main.js
@@ -28,8 +28,9 @@ async function main()
         "helipad": "Helipad Goldenhour",
         "papermill": "Papermill Ruins",
         "neutral": "Studio Neutral",
-        "chromatic": "Studio Chromatic",
-        "directional": "Studio Directional",
+        "Cannon_Exterior": "Cannon Exterior",
+        "Colorful_Studio": "Colorful Studio",
+        "Wide_Street" : "Wide Street",
     }, "assets/environments/");
 
     const uiModel = new UIModel(app, pathProvider, environmentPaths);


### PR DESCRIPTION
This uses the updated neutral.hdr with the current version from the certification.
Furhtermore, chromatic.hdr and directional.hdr are replaced with the actual used HDRs from the Certification
(Cannon_Exterior.hdr, Colorful_Studio.hdr, Wide_Street.hdr)
Resolves #349 