### PR TITLE
Add model "copyright" and "generator" tags to credits panel

### DIFF
--- a/app_web/index.html
+++ b/app_web/index.html
@@ -183,6 +183,7 @@
                                     </option>
                                 </b-select>
                             </b-field>
+                            <div class="modelCreditBottom">{{ modelCopyright }}</div>
                         </div>
                     </b-tab-item>
 
@@ -298,7 +299,7 @@
                     </b-tab-item>
 
 
-                    <b-tab-item label="XMP" icon="video" class="tabItemScrollable tab-item">
+                    <b-tab-item label="Credits" icon="video" class="tabItemScrollable tab-item">
                         <template #header>
                             <div @click="collapseActiveTab($event, 3)"
                                 v-bind:style="[tabsHidden === false && activeTab === 3 ? {'height': '100%'} : {}]">
@@ -307,14 +308,17 @@
                                     v-bind:width="[tabsHidden === false && activeTab === 3 ? '50px' : '30px']"
                                     v-bind:style="[tabsHidden === false && activeTab === 3 ? {'height': '100%'} : {}]">
                                 <span
-                                    v-bind:style="[tabsHidden === false && activeTab === 3 ? {'display': 'none'} : {}]">XMP</span>
+                                    v-bind:style="[tabsHidden === false && activeTab === 3 ? {'display': 'none'} : {}]">Credits</span>
                             </div>
                         </template>
 
                         <div class="tabContent">
                             <img src="assets/ui/Navigation_right_20px.svg" width="30px"
                                 @click="collapseActiveTab($event, 3)">
-                            <h2 class="title is-spaced">XMP</h2>
+                            <h2 class="title">Model Credits</h2>
+                            <div class="modelCredit">{{ modelCopyright }}</div>
+                            <div class="modelCredit">{{ modelGenerator }}</div>
+                            <h3 class="title">{{ xmp ? "XMP" : "" }}</h3>
                             <json-to-ui-template v-bind:data="xmp" v-bind:isinner="false"></json-to-ui-template>
                         </div>
                     </b-tab-item>

--- a/app_web/src/logic/uimodel.js
+++ b/app_web/src/logic/uimodel.js
@@ -411,11 +411,33 @@ class UIModel
                         return xmpPacket;
                     }
                 }
-                return [];
+                return null;
             })
         );
         xmpData.subscribe( (xmpData) => {
             this.app.xmp = xmpData;
+        });
+
+        const copyrightMsg = gltfLoadedAndInit.pipe(
+            map( (gltf) => {
+                if (gltf.asset.copyright)
+                    return gltf.asset.copyright;
+                return "";
+            })
+        );
+        copyrightMsg.subscribe( (copyright) => {
+            this.app.modelCopyright = copyright;
+        });
+
+        const generatorMsg = gltfLoadedAndInit.pipe(
+            map( (gltf) => {
+                if (gltf.asset.generator)
+                    return "Generator: " + gltf.asset.generator;
+                return "";
+            })
+        );
+        generatorMsg.subscribe( (generator) => {
+            this.app.modelGenerator = generator;
         });
 
         const animations = gltfLoadedAndInit.pipe(

--- a/app_web/src/ui/sass.scss
+++ b/app_web/src/ui/sass.scss
@@ -344,6 +344,24 @@ button.button
     height: 48px;
 }
 
+.modelCredit {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    word-break: break-word;
+}
+.modelCreditBottom {
+    margin-top: 1.5rem;
+    margin-right: 1em;
+    margin-bottom: 1.5rem;
+    word-break: break-word;
+}
+@media (min-height: 768px) {
+    .modelCreditBottom {
+        position: absolute;
+        bottom: 0;
+    }
+}
+
 #gltf-sample-viewer-model-spinner {
     position: absolute;
     top: 0;

--- a/app_web/src/ui/ui.js
+++ b/app_web/src/ui/ui.js
@@ -61,6 +61,8 @@ const app = new Vue({
             tonemaps: [{title: "None"}],
             debugchannels: [{title: "None"}],
             xmp: [{title: "xmp"}],
+            modelCopyright: "[not specified]",
+            modelGenerator: "[not specified]",
             statistics: [],
 
             selectedModel: "DamagedHelmet",

--- a/app_web/src/ui/ui.js
+++ b/app_web/src/ui/ui.js
@@ -61,8 +61,8 @@ const app = new Vue({
             tonemaps: [{title: "None"}],
             debugchannels: [{title: "None"}],
             xmp: [{title: "xmp"}],
-            modelCopyright: "[not specified]",
-            modelGenerator: "[not specified]",
+            modelCopyright: "",
+            modelGenerator: "",
             statistics: [],
 
             selectedModel: "DamagedHelmet",


### PR DESCRIPTION
This is based on a comment by @javagl during the Tooling TSG meeting earlier today.  It was pointed out that the Sample Viewer doesn't display a credit line for models that are marked CC-BY or similar.

I've renamed the "XMP" tab to "Credits" and included `asset.copyright` and `asset.generator` above the existing XMP data (if any) on the tab.  I also placed a copy of `asset.copyright` alone at the bottom of the "Model" tab, for visibility.

Unfortunately this has highlighted that a great many sample models are completely missing `asset.copyright` information, particularly ones marked CC-BY that need to be carrying that information.  However, many models contributed by myself and @echadwick-wayfair do indeed include the correct license in the `asset.copyright` field, for example "IridescentDishWithOlives," "EmissiveStrengthTest," etc.

So for most sample models, this change doesn't appear to do very much, but for the models that carry copyrights in the asset tag, this will reveal the credits to the user.