### PR TITLE
use spec. for ang. attenuation

### DIFF
--- a/source/Renderer/shaders/punctual.glsl
+++ b/source/Renderer/shaders/punctual.glsl
@@ -46,9 +46,7 @@ float getSpotAttenuation(vec3 pointToLight, vec3 spotDirection, float outerConeC
     {
         if (actualCos < innerConeCos)
         {
-            //return smoothstep(outerConeCos, innerConeCos, actualCos);
-            //spec. recommendation
-            float angularAttenuation = (actualCos - outerConeCos)/(innerConeCos - outerConeCos);
+            float angularAttenuation = (actualCos - outerConeCos) / (innerConeCos - outerConeCos);
             return angularAttenuation * angularAttenuation;
         }
         return 1.0;

--- a/source/Renderer/shaders/punctual.glsl
+++ b/source/Renderer/shaders/punctual.glsl
@@ -46,7 +46,10 @@ float getSpotAttenuation(vec3 pointToLight, vec3 spotDirection, float outerConeC
     {
         if (actualCos < innerConeCos)
         {
-            return smoothstep(outerConeCos, innerConeCos, actualCos);
+            //return smoothstep(outerConeCos, innerConeCos, actualCos);
+            //spec. recommendation
+            float angularAttenuation = (actualCos - outerConeCos)/(innerConeCos - outerConeCos);
+            return angularAttenuation * angularAttenuation;
         }
         return 1.0;
     }


### PR DESCRIPTION
in spot lights, rather than smoothstep