### PR TITLE
Replace `axios` by `fetch`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
         "sourceType": "module"
     },
     "globals":{
-        "axios": false,
         "dat": false,
         "Stats": false
     },

--- a/app_web/package.json
+++ b/app_web/package.json
@@ -25,7 +25,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@khronosgroup/gltf-viewer": "..",
-    "axios": "^0.21.1",
     "buefy": "^0.9.4",
     "fast-png": "^5.0.3",
     "gl-matrix": "^3.2.1",

--- a/app_web/rollup.config.js
+++ b/app_web/rollup.config.js
@@ -29,7 +29,7 @@ export default {
         resolve({
             browser: true,
             preferBuiltins: true,
-            dedupe: ['gl-matrix', 'axios', 'jpeg-js', 'fast-png']
+            dedupe: ['gl-matrix', 'jpeg-js', 'fast-png']
         }),
         builtins(),
         scss(),

--- a/app_web/src/model_path_provider.js
+++ b/app_web/src/model_path_provider.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import path from 'path';
 
 export class GltfModelPathProvider
@@ -12,9 +11,8 @@ export class GltfModelPathProvider
 
     async initialize()
     {
-        const self = this;
-        const response = await axios.get(this.modelIndexerPath);
-        self.populateDictionary(response.data);
+        const response = await fetch(this.modelIndexerPath);
+        this.populateDictionary(await response.json());
     }
 
     resolve(modelKey, flavour)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "Khronos Group Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "axios": "^0.23.0",
     "fast-png": "^5.0.3",
     "gl-matrix": "^3.2.1",
     "jpeg-js": "^0.4.3"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ export default {
         resolve({
             browser: false,
             preferBuiltins: false,
-            dedupe: ['gl-matrix', 'axios', 'jpeg-js', 'fast-png']
+            dedupe: ['gl-matrix', 'jpeg-js', 'fast-png']
         }),
         copy({
             targets: [

--- a/source/ResourceLoader/resource_loader.js
+++ b/source/ResourceLoader/resource_loader.js
@@ -1,5 +1,3 @@
-
-import axios from 'axios';
 import { glTF } from '../gltf/gltf.js';
 import { getIsGlb, getContainingFolder } from '../gltf/utils.js';
 import { GlbParser } from './glb_parser.js';
@@ -54,9 +52,8 @@ class ResourceLoader
         if (typeof gltfFile === "string")
         {
             isGlb = getIsGlb(gltfFile);
-            let response = await axios.get(gltfFile, { responseType: isGlb ? "arraybuffer" : "json" });
-            json = response.data;
-            data = response.data;
+            const response = await fetch(gltfFile);
+            json = data = await (isGlb ? response.arrayBuffer() : response.json());
             filename = gltfFile;
         }
         else if (gltfFile instanceof ArrayBuffer)
@@ -129,9 +126,8 @@ class ResourceLoader
         let image = undefined;
         if (typeof environmentFile === "string")
         {
-            let response = await axios.get(environmentFile, { responseType: "arraybuffer" });
-
-            image = await loadHDR(new Uint8Array(response.data));
+            let response = await fetch(environmentFile);
+            image = await loadHDR(new Uint8Array(await response.arrayBuffer()));
         }
         else if (environmentFile instanceof ArrayBuffer)
         {
@@ -334,12 +330,12 @@ async function _loadEnvironmentFromPanorama(imageHDR, view, luts)
     }
 
     environment.images.push(new gltfImage(
-        undefined, 
-        GL.TEXTURE_2D, 
-        0, 
-        undefined, 
-        undefined, 
-        ImageMimeType.GLTEXTURE, 
+        undefined,
+        GL.TEXTURE_2D,
+        0,
+        undefined,
+        undefined,
+        ImageMimeType.GLTEXTURE,
         environmentFiltering.ggxLutTextureID));
     const lutTexture = new gltfTexture(lutSamplerIdx, [imageIdx++], GL.TEXTURE_2D);
     lutTexture.initialized = true; // iblsampler has already initialized the texture
@@ -351,12 +347,12 @@ async function _loadEnvironmentFromPanorama(imageHDR, view, luts)
     // Sheen
     // Charlie
     environment.images.push(new gltfImage(
-        undefined, 
-        GL.TEXTURE_2D, 
-        0, 
-        undefined, 
-        undefined, 
-        ImageMimeType.GLTEXTURE, 
+        undefined,
+        GL.TEXTURE_2D,
+        0,
+        undefined,
+        undefined,
+        ImageMimeType.GLTEXTURE,
         environmentFiltering.charlieLutTextureID));
     const charlieLut = new gltfTexture(lutSamplerIdx, [imageIdx++], GL.TEXTURE_2D);
     charlieLut.initialized = true; // iblsampler has already initialized the texture

--- a/source/gltf/buffer.js
+++ b/source/gltf/buffer.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { getContainingFolder } from './utils.js';
 import { GltfObject } from './gltf_object.js';
 
@@ -41,13 +40,13 @@ class gltfBuffer extends GltfObject
             return false;
         }
 
-        const self = this;
-        axios.get(getContainingFolder(gltf.path) + this.uri, { responseType: 'arraybuffer'})
-            .then(function(response)
-            {
-                self.buffer = response.data;
+        fetch(getContainingFolder(gltf.path) + this.uri)
+            .then(response => response.arrayBuffer())
+            .then(buffer => {
+                this.buffer = buffer;
                 callback();
             });
+
         return true;
     }
 

--- a/source/package.json
+++ b/source/package.json
@@ -14,7 +14,6 @@
   "author": "Khronos Group Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "axios": "^0.21.1",
     "fast-png": "^5.0.3",
     "gl-matrix": "^3.2.1",
     "jpeg-js": "^0.4.3"


### PR DESCRIPTION
Replaces the calls to the Axios package by the built-in fetch API. This also resolves [this security issue](https://github.com/KhronosGroup/glTF-Sample-Viewer/security/dependabot/7).