### PR TITLE
Update "PBR Neutral" tone mapping with recent change.

### DIFF
--- a/API.md
+++ b/API.md
@@ -366,7 +366,7 @@ by gltf sample viewer
 <a name="GltfState.ToneMaps.KHR_PBR_NEUTRAL"></a>
 
 #### ToneMaps.KHR\_PBR\_NEUTRAL
-Khronos PBR neutral tone mapping, see https://modelviewer.dev/examples/tone-mapping
+Khronos PBR neutral tone mapping, see https://github.com/KhronosGroup/ToneMapping, https://modelviewer.dev/examples/tone-mapping
 
 **Kind**: static property of [<code>ToneMaps</code>](#GltfState.ToneMaps)  
 <a name="GltfState.ToneMaps.ACES_HILL_EXPOSURE_BOOST"></a>

--- a/source/GltfState/gltf_state.js
+++ b/source/GltfState/gltf_state.js
@@ -82,9 +82,9 @@ class GltfState
             /**
              * By default the front face of the environment is +Z (90)
              * Front faces:
-             * +X = 0 
-             * +Z = 90 
-             * -X = 180 
+             * +X = 0
+             * +Z = 90
+             * -X = 180
              * -Z = 270
              */
             environmentRotation: 90.0,
@@ -99,12 +99,12 @@ class GltfState
     }
 }
 
-/** 
- * ToneMaps enum for the different tonemappings that are supported 
+/**
+ * ToneMaps enum for the different tonemappings that are supported
  * by gltf sample viewer
 */
 GltfState.ToneMaps = {
-    /** Khronos PBR neutral tone mapping, see https://modelviewer.dev/examples/tone-mapping */
+    /** Khronos PBR neutral tone mapping, see https://github.com/KhronosGroup/ToneMapping, https://modelviewer.dev/examples/tone-mapping */
     KHR_PBR_NEUTRAL: "Khronos PBR Neutral",
     /** ACES sRGB RRT+ODT implementation for 3D Commerce based on Stephen Hill's implementation with a exposure factor of 1.0 / 0.6 */
     ACES_HILL_EXPOSURE_BOOST: "ACES Filmic Tone Mapping (Hill - Exposure Boost)",
@@ -169,7 +169,7 @@ GltfState.DebugOutput = {
         /** output the clear coat roughness */
         CLEARCOAT_ROUGHNESS: "ClearCoat Roughness",
         /** output the clear coat normal */
-        CLEARCOAT_NORMAL: "ClearCoat Normal",    
+        CLEARCOAT_NORMAL: "ClearCoat Normal",
     },
 
     /** output sheen lighting */

--- a/source/Renderer/shaders/tonemapping.glsl
+++ b/source/Renderer/shaders/tonemapping.glsl
@@ -68,7 +68,7 @@ vec3 RRTAndODTFit(vec3 color)
 }
 
 
-// tone mapping 
+// tone mapping
 vec3 toneMapACES_Hill(vec3 color)
 {
     color = ACESInputMat * color;
@@ -86,10 +86,11 @@ vec3 toneMapACES_Hill(vec3 color)
 
 // Khronos PBR neutral tone mapping
 #ifdef TONEMAP_KHR_PBR_NEUTRAL
-float startCompression = 0.8 - 0.04;
-float desaturation = 0.15;
 vec3 toneMap_KhronosPbrNeutral( vec3 color )
 {
+    const float startCompression = 0.8 - 0.04;
+    const float desaturation = 0.15;
+
     float x = min(color.r, min(color.g, color.b));
     float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
     color -= offset;
@@ -97,12 +98,12 @@ vec3 toneMap_KhronosPbrNeutral( vec3 color )
     float peak = max(color.r, max(color.g, color.b));
     if (peak < startCompression) return color;
 
-    float d = 1. - startCompression;
+    const float d = 1. - startCompression;
     float newPeak = 1. - d * d / (peak + d - startCompression);
     color *= newPeak / peak;
 
     float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
-    return mix(color, vec3(1, 1, 1), g);
+    return mix(color, newPeak * vec3(1, 1, 1), g);
 }
 #endif
 


### PR DESCRIPTION
Updated the "Khronos PBR Neutral" tone mapper with a small mathematical tweak that was published to its new location:

https://github.com/KhronosGroup/ToneMapping/blob/main/PBR_Neutral/pbrNeutral.glsl

I recall this change was desired to make the tone mapper mathematically invertible.  Also some trailing whitespace was removed.

/cc @elalish 