### PR TITLE
Fix/wasm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/KhronosGroup/glTF-Sample-Viewer.git"
   },
   "scripts": {
-    "build": "echo 'Please run `npm run build` from the `app_web` or `app_headless` directory.'",
+    "build": "rollup -c",
     "dev": "echo 'Please run `npm run dev` from the `app_web` or `app_headless` directory.'",
     "prepublishOnly": "npm run build && npm run build_docs",
     "build_docs": "./node_modules/.bin/jsdoc2md source/gltf-sample-viewer.js source/GltfView/gltf_view.js source/GltfState/gltf_state.js source/ResourceLoader/resource_loader.js source/gltf/user_camera.js > API.md",
@@ -31,15 +31,15 @@
     "jpeg-js": "^0.4.3"
   },
   "devDependencies": {
-    "rollup": "^2.79.1",
-    "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-glslify": "^1.3.1",
-    "@rollup/plugin-wasm": "^6.1.3",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
+    "@rollup/plugin-wasm": "^6.1.3",
     "concurrently": "^7.4.0",
     "eslint": "^8.24.0",
     "jsdoc-to-markdown": "^7.1.1",
+    "rollup": "^2.79.1",
+    "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-glslify": "^1.3.1",
     "serve": "^14.0.1"
   },
   "bugs": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default {
         wasm( {fileName: "libs/[name][extname]", publicPath: "./"} ),
         glslify(),
         resolve({
-            browser: false,
+            browser: true,
             preferBuiltins: false,
             dedupe: ['gl-matrix', 'jpeg-js', 'fast-png']
         }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default {
         }
     ],
     plugins: [
-        wasm(),
+        wasm( {fileName: "libs/[name][extname]", publicPath: "./"} ),
         glslify(),
         resolve({
             browser: false,


### PR DESCRIPTION
Mikktspace introduced a util dependecy which can be resolved by setting the browser setting to true.
Also the WASM file is now copied to the same location as the ktx one and not auto renamed.
In render-fidelity-tools the local path to the WASM file is resolved wrongly, but I think this issues can not be resolved in sample viewer.

It might be a good idea to investigate auto discovery of resources such as WASM files or LUTs in the future.