### PR TITLE
Refactor attenuation math to avoid -log(0.0)

### DIFF
--- a/source/Renderer/shaders/punctual.glsl
+++ b/source/Renderer/shaders/punctual.glsl
@@ -119,8 +119,7 @@ vec3 applyVolumeAttenuation(vec3 radiance, float transmissionDistance, vec3 atte
     else
     {
         // Compute light attenuation using Beer's law.
-        vec3 attenuationCoefficient = -log(attenuationColor) / attenuationDistance;
-        vec3 transmittance = exp(-attenuationCoefficient * transmissionDistance); // Beer's law
+        vec3 transmittance = pow(attenuationColor, vec3(transmissionDistance / attenuationDistance));
         return transmittance * radiance;
     }
 }


### PR DESCRIPTION
The math can be simplified per @lexaknyazev's refactoring in https://github.com/KhronosGroup/glTF/issues/2390#issuecomment-2158480643.

This avoids a situation where the attenuationColor might have some or all zeros in it, causing a `log(0)` error in the shader.

I've successfully tested this with sample assets AttenuationTest, DragonAttenuation, and the custom test from the above-linked issue.