### PR TITLE
Catch error during gltf loading and clear with empty gltf [574]

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -152,6 +152,19 @@ export default async () => {
                         uiModel.exitLoadingState();
 
                         return state;
+                    }).catch((error) => {
+                        console.error("fail: "+error);
+                        resourceLoader
+                        .loadGltf(undefined,undefined)
+                        .then((gltf) => {
+                            state.gltf = gltf;
+                            state.sceneIndex =  0 ;
+                            state.cameraIndex = undefined;
+
+                            uiModel.exitLoadingState();
+                            redraw = true;
+                        }); 
+                        return state;
                     })
             );
         }),

--- a/src/main.js
+++ b/src/main.js
@@ -153,17 +153,17 @@ export default async () => {
 
                         return state;
                     }).catch((error) => {
-                        console.error("fail: "+error);
+                        console.error("Loading failed: "+ error);
                         resourceLoader
-                        .loadGltf(undefined,undefined)
-                        .then((gltf) => {
-                            state.gltf = gltf;
-                            state.sceneIndex =  0 ;
-                            state.cameraIndex = undefined;
+                            .loadGltf(undefined, undefined)
+                            .then((gltf) => {
+                                state.gltf = gltf;
+                                state.sceneIndex = 0;
+                                state.cameraIndex = undefined;
 
-                            uiModel.exitLoadingState();
-                            redraw = true;
-                        }); 
+                                uiModel.exitLoadingState();
+                                redraw = true;
+                            }); 
                         return state;
                     })
             );


### PR DESCRIPTION
Prevent stopping user interface when broken glTF was loaded and clear with empty glTF instead.

https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/574