### PR TITLE
Draft for handling ignored validation warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,11 @@
                                         <p>Number of warnings: {{validationReport?.issues?.numWarnings ?? 0}}</p>
                                         <p>Number of infos: {{validationReport?.issues?.numInfos ?? 0}}</p>
                                     </div>
+
+                                    <div v-show='validationReportDescription?.message !== ""'>
+                                        <p style="margin-top: 10px; margin-bottom: 10px; font-size:smaller;">{{validationReportDescription?.message}}</p>
+                                    </div>
+
                                     <button class="button is-rounded" style="width: fit-content; flex-shrink: 0; margin-bottom: 12px;" v-on:click="copyToClipboard(JSON.stringify(validationReport, undefined, 4))">Copy</button>
                                     <button class="button is-rounded" style="width: fit-content; flex-shrink: 0;" v-on:click="downloadJSON(validationReport?.uri?.substring(validationReport.uri.lastIndexOf('/') + 1) + '.report.json', validationReport)">Download</button>
                                     <span style="margin-top: 5px;">Powered by <a href="https://github.com/KhronosGroup/glTF-Validator" target="_blank" rel="noopener noreferrer">glTF-Validator</a></span>

--- a/src/logic/uimodel.js
+++ b/src/logic/uimodel.js
@@ -230,9 +230,39 @@ class UIModel
         );
     }
 
+    createValidationReportDescription(validationReport) {
+        const issues = validationReport?.issues;
+        const messages = issues?.messages;
+        const numWarnings = issues?.numWarnings ?? 0;
+        if (!issues || !messages || numWarnings === 0) {
+            return {};
+        }
+        let numIgnoredWarnings = 0;
+        for (const message of messages) {
+            if (message.code === "MESH_PRIMITIVE_GENERATED_TANGENT_SPACE") {
+                numIgnoredWarnings++;
+            }
+        }
+        if (numIgnoredWarnings === 0) {
+            return {};
+        }
+        return {
+            numIgnoredWarnings: numIgnoredWarnings,
+            message: `The validation generated ${issues.numWarnings} warnings. `
+                +`${numIgnoredWarnings} of these warnings have been about missing `
+                +`tangent space information. Omitting the tangent space information `
+                +`may be a conscious decision by the designer, but it may limit `
+                +`the portability of the asset. The glTF-Sample-Viewer generates `
+                +`tangents using the default MikkTSpace algorithm in this case.`
+        };
+    }
+
     updateValidationReport(validationReportObservable)
     {
-        validationReportObservable.subscribe(data => this.app.validationReport = data);
+        validationReportObservable.subscribe(data => {
+            this.app.validationReport = data;
+            this.app.validationReportDescription = this.createValidationReportDescription(data);
+        });
     }
 
     disabledAnimations(disabledAnimationsObservable)

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import {validateBytes} from "gltf-validator";
 
 const ignoredIssues = [
     // This sample renderer supports tangent space generation.
-    "MESH_PRIMITIVE_GENERATED_TANGENT_SPACE"
+    //"MESH_PRIMITIVE_GENERATED_TANGENT_SPACE"
 ];
 
 export default async () => {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -74,6 +74,7 @@ const appCreated = createApp({
             disabledAnimations: [],
 
             validationReport: {},
+            validationReportDescription: {},
 
             ibl: true,
             iblIntensity: 0.0,
@@ -223,24 +224,38 @@ const appCreated = createApp({
             document.body.removeChild(element);
         },
         getValidationCounter: function(){
-            let number = 0;
+            let info = "";
             let color = "white";
             if (this.validationReport?.issues?.numErrors > 0) {
-                number = this.validationReport?.issues?.numErrors;
+                info = `${this.validationReport?.issues?.numErrors}`;
                 color = "red";
             } else if (this.validationReport?.issues?.numWarnings > 0) {
-                number = this.validationReport?.issues?.numWarnings;
-                color = "yellow";
+                if (this.validationReportDescription.numIgnoredWarnings == this.validationReport?.issues?.numWarnings) {
+                    color = "lightBlue";
+                    info = "i";
+                } else {
+                    info = `${this.validationReport?.issues?.numWarnings}`;
+                    color = "yellow";
+                }
             } else if (this.validationReport?.issues?.numInfos > 0) {
-                number = this.validationReport?.issues?.numInfos;
+                info = `${info = this.validationReport?.issues?.numInfos}`;
             }
-            if (number !== 0) {
-                return `<div style="display:flex;color:black; font-weight:bold; background-color:${color}; border-radius:50%; width:fit-content; min-width:2rem; align-items:center;aspect-ratio:1/1;justify-content:center;">${number}</div>`;
+            let infoDiv = "";
+            if (info !== "") {
+                infoDiv = `<div style="display:flex;color:black; position:absolute; left:50%; top:0px; ` 
+                    + `font-weight:bold; background-color:${color}; border-radius:50%; width:fit-content; ` 
+                    + `min-width:2rem; align-items:center;aspect-ratio:1/1;justify-content:center;">${info}</div>`;
             }
             if (this.tabsHidden === false && this.activeTab === 2) {
-                return `<img src="assets/ui/Capture 50X50.svg" width="50px" height="100%">`;
+                return `<div>` 
+                    + `<img src="assets/ui/Capture 50X50.svg" width="50px" height="100%">` 
+                    + infoDiv  
+                    + `</div>`;
             }
-            return '<img src="assets/ui/Capture 30X30.svg" width="30px">';
+            return `<div>` 
+                + `<img src="assets/ui/Capture 30X30.svg" width="30px">` 
+                + infoDiv  
+                + `</div>`;
         },
         setAnimationState: function(value)
         {


### PR DESCRIPTION
There has been some feedback saying that the scary, yellow "Validation warnings" indicator, and the message
"Number of warnings: 123"
could be confusing, and raise questions for end users:

![Khronos Sample Viewer Warnings](https://github.com/user-attachments/assets/bb1d23a0-16b7-44ad-9d9c-257efb048d2d)

<sup>Dramatization via emoji by me</sup>

A specific aspect that raised concerns here was that many of the official sample models do generate warnings. And without further context, this could give users the impression that ~"The sample models are not _really_ valid, _somehow_...". But this is not the case. The sample models _are_ valid. And there are models some that even are _intended_ for testing cases that generate warnings.  

However, _most_ of the warnings that had been generated for the "Showcase" models had been 
`MESH_PRIMITIVE_GENERATED_TANGENT_SPACE`
which is described as

> Material requires a tangent space but the mesh primitive does not provide it. Runtime-generated tangent space may be non-portable across implementations.

Leaving out the tangent space information can be a conscious decision by the creator of the model (to reduce the size). But it _can_ limit portability in cases where the renderer/viewer does not generate proper tangent space information.

---

Different options for addressing this have been discussed in the 3D Formats Tooling Working Group. A [previous pull request](https://github.com/KhronosGroup/glTF-Sample-Viewer/pull/589) simply disabled this warning on the level of the validator. An undesirable side-effect of this was that 

1. the official sample viewer and the official validator (drag-and-drop tools) behaved differently and generated different reports
2. there was _no_ indication of this warning any more (meaning that users could think their asset was warning-free, although it isn't)

---

Another option is drafted (!) here:

When there are "infos", then the number of infos is displayed in a white circle:

![Khronos Sample Viewer Info](https://github.com/user-attachments/assets/ec876fd1-6f58-451e-ae3c-63af7996e619)

When there are "errors", then the number of errors is displayed in a red circle:

![Khronos Sample Viewer Error](https://github.com/user-attachments/assets/1cb02b1f-e2d4-46a8-9aa7-2e9dc5fb4d58)

When there are warnings, the special handling kicks in:

When there is **any** warning that is **not** one of the "ignored" `MESH_PRIMITIVE_GENERATED_TANGENT_SPACE` warnings, then the total number of warnings is displayed in a yellow circle:

![Khronos Sample Viewer Warning](https://github.com/user-attachments/assets/ce4f2b7e-e5f9-4739-bb84-4d81a4c7923c)

When **all** the warnings are the "ignored" are `MESH_PRIMITIVE_GENERATED_TANGENT_SPACE` ones, then it shows an innocent, calming, "i" (for "info") in a Pale Blue Dot. 

If there have been "ignored" warnings, then the validator tab will show an elaborate message, saying _how many_ warnings have been "ignored", and explaining the reason why this is OK for the sample viewer. (Wording TBD) 

![Khronos Sample Viewer Warnings New](https://github.com/user-attachments/assets/e786b0b4-5dd6-42c8-aa19-a95a068594bc)

---

The current state of this PR is a DRAFT, to illustrate what this may look like for the end user. 

The implementation will have to be cleaned up. And whenever I have to do anything that even remotely involves CSS, I'm reminded why I am not (and will never be) a web frontend developer. But I can do _some_ cleanups, at least (e.g. the change from the [previous PR](https://github.com/KhronosGroup/glTF-Sample-Viewer/pull/589) is just commented out here). 


@DRx3D @emackey @lexaknyazev
