### PR TITLE
Fix UI cutoff on mobile

### DIFF
--- a/src/ui/sass.scss
+++ b/src/ui/sass.scss
@@ -133,12 +133,12 @@ nav.tabs
 // handle options placement
 .tabs li:first-child
 {
-    margin-top: calc(100vh * 0.11);
+    margin-top: calc(100dvh * 0.11);
 }
 .tabs li:nth-child(7)
 {
     margin-top: auto;
-    margin-bottom: calc(100vh * 0.02);
+    margin-bottom: calc(100dvh * 0.02);
 }
 
 .tabs li a

--- a/src/ui/sass.scss
+++ b/src/ui/sass.scss
@@ -94,7 +94,7 @@ body
 /* tab selection on the right */
 .b-tabs.is-vertical
 {
-    height: 100vh;
+    height: 100dvh;
 }
 
 nav.tabs

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -125,7 +125,7 @@ const appCreated = createApp({
     },
     beforeMount: function(){
         // Definition of mobile: https://bulma.io/documentation/start/responsiveness/
-        if(window.innerWidth > 768) { 
+        if(document.documentElement.clientWidth > 768) { 
             this.uiVisible = true;
             this.isMobile = false;
         } else {


### PR DESCRIPTION
Mobile browser can overlap the page with their own ui elements. These do not reduce the vh property used in css. This can be mitigated using the dvh (dynamic view height) property instead.

fixes KhronosGroup/glTF-Sample-Viewer#593


(Additionally this pr replaces window.innerWidth with documen.documentElement.clientWidth for mobile detection, since the former does not report the actual window width on ios. [mozilla innerWidth](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth) [webkit bug](https://bugs.webkit.org/show_bug.cgi?id=174362) )