### PR TITLE
Do not show toast for injected code (URL does not exist)

### DIFF
--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -409,6 +409,10 @@ canvasUI.mount('#canvasUI');
     };
 
     window.onerror = function(msg, url, lineNo, columnNo, error) {
+        // If error is not from the sample viewer, ignore it
+        if (url === undefined || url === null || url === "") {
+            return;
+        }
         app.error([
             'Message: ' + msg,
             'URL: ' + url,


### PR DESCRIPTION
Fixes #599

The error from this issue is caused by a firefox bug in injected code for form autocompletion.
With this fix this error (and all errors without script URL) is not shown via our error toast.