### PR TITLE
Fix/absolute URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
                                 <img src="assets/ui/Navigation_right_20px.svg" width="30px"
                                     @click="collapseActiveTab($event, 2)">
                                 <h2 class="title is-spaced" v-bind:data="validationReport">glTF Validator</h2>
-                                    <div class="modelCredit" v-show='validationReport.error === undefined'>
+                                    <div class="modelCredit" v-show='validationReport?.error === undefined'>
                                         <p>Number of errors: {{validationReport?.issues?.numErrors ?? 0}}</p>
                                         <p>Number of warnings: {{validationReport?.issues?.numWarnings ?? 0}}</p>
                                         <p>Number of infos: {{validationReport?.issues?.numInfos ?? 0}}</p>
@@ -330,12 +330,12 @@
                                         <p style="margin-top: 10px; margin-bottom: 10px; font-size:smaller;">{{validationReportDescription?.message}}</p>
                                     </div>
 
-                                    <div v-show="validationReport.error !== undefined">
-                                        <p style="margin-top: 10px; margin-bottom: 10px; color:red;">{{validationReport.error}}</p>
+                                    <div v-show="validationReport?.error !== undefined">
+                                        <p style="margin-top: 10px; margin-bottom: 10px; color:red;">{{validationReport?.error}}</p>
                                     </div>
 
-                                    <button v-show="validationReport.error === undefined" class="button is-rounded" style="width: fit-content; flex-shrink: 0; margin-bottom: 12px;" v-on:click="copyToClipboard(JSON.stringify(validationReport, undefined, 4))">Copy</button>
-                                    <button v-show="validationReport.error === undefined" class="button is-rounded" style="width: fit-content; flex-shrink: 0;" v-on:click="downloadJSON(validationReport?.uri?.substring(validationReport.uri.lastIndexOf('/') + 1) + '.report.json', validationReport)">Download</button>
+                                    <button v-show="validationReport?.error === undefined" class="button is-rounded" style="width: fit-content; flex-shrink: 0; margin-bottom: 12px;" v-on:click="copyToClipboard(JSON.stringify(validationReport, undefined, 4))">Copy</button>
+                                    <button v-show="validationReport?.error === undefined" class="button is-rounded" style="width: fit-content; flex-shrink: 0;" v-on:click="downloadJSON(validationReport?.uri?.substring(validationReport?.uri?.lastIndexOf('/') + 1) + '.report.json', validationReport)">Download</button>
                                     <span style="margin-top: 5px;">Powered by <a href="https://github.com/KhronosGroup/glTF-Validator" target="_blank" rel="noopener noreferrer">glTF-Validator</a></span>
                                 </b-field>
                             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3066,8 +3066,9 @@
       }
     },
     "node_modules/gl-matrix": {
-      "version": "3.4.3",
-      "license": "MIT"
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -7660,7 +7661,9 @@
       "dev": true
     },
     "gl-matrix": {
-      "version": "3.4.3"
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="
     },
     "glob-parent": {
       "version": "6.0.2",

--- a/src/logic/uimodel.js
+++ b/src/logic/uimodel.js
@@ -386,12 +386,18 @@ const getInputObservables = (inputElement, app) => {
 
     // Partition files into a .gltf or .glb and additional files like buffers and textures
     observables.droppedGltf = droppedFiles.pipe(
-        map((files) => ({
-            mainFile: files.find(([path]) => path.endsWith(".glb") || path.endsWith(".gltf")),
-            additionalFiles: files.filter(
-                (file) => !file[0].endsWith(".glb") && !file[0].endsWith(".gltf")
-            )
-        })),
+        map((files) => {
+            files = files.map((file) => {
+                let filePath = file[0].replaceAll("\\", "/");
+                return [filePath.substring(1), file[1]]; // remove leading slash
+            });
+            return {
+                mainFile: files.find(([path]) => path.endsWith(".glb") || path.endsWith(".gltf")),
+                additionalFiles: files.filter(
+                    (file) => !file[0].endsWith(".glb") && !file[0].endsWith(".gltf")
+                )
+            };
+        }),
         filter(({ mainFile, additionalFiles }) => {
             let isDefined = mainFile !== undefined;
 
@@ -403,33 +409,6 @@ const getInputObservables = (inputElement, app) => {
             }
 
             return isDefined;
-        }),
-        map(({ mainFile, additionalFiles }) => {
-            if (mainFile[0].endsWith(".gltf")) {
-                // extract folder path from gltf file
-                let folderPath = mainFile[0];
-                // replace all \ by /
-                folderPath = folderPath.replaceAll("\\", "/");
-                // remove filename
-                folderPath = folderPath.substr(0, folderPath.lastIndexOf("/"));
-
-                if (folderPath !== "") {
-                    // remove folder path from additional files
-                    additionalFiles = additionalFiles.map((file) => {
-                        let filePath = file[0].replaceAll("\\", "/");
-                        if (filePath.startsWith(folderPath)) {
-                            return [filePath.substr(folderPath.length), file[1]];
-                        } else {
-                            return file;
-                        }
-                    });
-                }
-            }
-
-            return {
-                mainFile: mainFile,
-                additionalFiles: additionalFiles
-            };
         }),
         filter((files) => files.mainFile !== undefined)
     );

--- a/src/logic/uimodel.js
+++ b/src/logic/uimodel.js
@@ -392,10 +392,13 @@ const getInputObservables = (inputElement, app) => {
                 (file) => !file[0].endsWith(".glb") && !file[0].endsWith(".gltf")
             )
         })),
-        filter(({ mainFile }) => {
+        filter(({ mainFile, additionalFiles }) => {
             let isDefined = mainFile !== undefined;
 
-            if (!isDefined) {
+            if (
+                !isDefined &&
+                !(additionalFiles.length === 1 && additionalFiles[0][0].endsWith(".hdr"))
+            ) {
                 console.warn("Only glTF, glb and hdr files can be loaded on drop.");
             }
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ export default async () => {
     const state = view.createState();
     state.renderingParameters.useDirectionalLightsWithDisabledIBL = true;
 
+    const emptyGltf = await resourceLoader.loadGltf(undefined, undefined, false);
+
     const pathProvider = new GltfModelPathProvider(
         "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main"
     );
@@ -133,7 +135,7 @@ export default async () => {
 
             return from(
                 resourceLoader
-                    .loadGltf(model.mainFile, model.additionalFiles)
+                    .loadGltf(model.mainFile, model.additionalFiles, false)
                     .then((gltf) => {
                         state.gltf = gltf;
                         const defaultScene = state.gltf.scene;
@@ -177,14 +179,11 @@ export default async () => {
                     })
                     .catch((error) => {
                         console.error("Loading failed: " + error);
-                        resourceLoader.loadGltf(undefined, undefined).then((gltf) => {
-                            state.gltf = gltf;
-                            state.sceneIndex = 0;
-                            state.cameraNodeIndex = undefined;
-
-                            uiModel.exitLoadingState();
-                            redraw = true;
-                        });
+                        state.gltf = emptyGltf;
+                        state.sceneIndex = 0;
+                        state.cameraNodeIndex = undefined;
+                        uiModel.exitLoadingState();
+                        redraw = true;
                         return state;
                     })
             );

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { GltfView } from "@khronosgroup/gltf-viewer";
+import { GltfView, ResourceLoaderUtils } from "@khronosgroup/gltf-viewer";
 
 import { UIModel } from "./logic/uimodel.js";
 import { app } from "./ui/ui.js";
@@ -80,12 +80,20 @@ export default async () => {
                         });
                     } else if (Array.isArray(model.mainFile)) {
                         const externalRefFunction = (uri) => {
-                            uri = "/" + uri;
                             return new Promise((resolve, reject) => {
                                 let foundFile = undefined;
                                 for (let i = 0; i < model.additionalFiles.length; i++) {
                                     const file = model.additionalFiles[i];
-                                    if (file[0] == uri) {
+                                    let actualPath = uri;
+                                    if (!ResourceLoaderUtils.isAbsoluteUrl(uri)) {
+                                        const parentPath = ResourceLoaderUtils.getContainingFolder(
+                                            model.mainFile[0]
+                                        );
+                                        actualPath = ResourceLoaderUtils.cleanRelativePath(
+                                            parentPath + uri
+                                        );
+                                    }
+                                    if (file[0] == actualPath) {
                                         foundFile = file[1];
                                         break;
                                     }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -260,7 +260,7 @@ const appCreated = createApp({
             let info = "";
             let color = "white";
             const padding = this.isMobile ? "right:-3px;top:-18px;" : "right:-18px;top:-18px;";
-            if (this.validationReport.error) {
+            if (this.validationReport?.error) {
                 info = "X";
                 color = "red";
                 return (


### PR DESCRIPTION
Fixes #637
Sample Viewer now disallows absolute paths for glTF sub-resources (URIs defined in JSON) for security reasons.
This is configurable in the ResourceLoader of the renderer.