### PR TITLE
Smooth drag/scroll input with easeInOutSine pulses

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,8 @@
                                     </b-select>
                                 </b-field>
 
+                                <b-switch v-model="inputSmoothing" v-on:input="inputSmoothingChanged.next($event.target.checked)">Input Smoothing</b-switch>
+                                <br>
                                 <b-switch v-model="skinning" v-on:input="skinningChanged.next($event.target.checked)">Skinning</b-switch>
                                 <br>
                                 <b-switch v-model="morphing" v-on:input="morphingChanged.next($event.target.checked)">Morphing</b-switch>

--- a/src/logic/uimodel.js
+++ b/src/logic/uimodel.js
@@ -49,6 +49,7 @@ class UIModel {
 
         this.exposure = app.exposureChanged.pipe();
         this.skinningEnabled = app.skinningChanged.pipe();
+        this.inputSmoothingEnabled = app.inputSmoothingChanged.pipe();
         this.morphingEnabled = app.morphingChanged.pipe();
         this.clearcoatEnabled = app.clearcoatChanged.pipe();
         this.sheenEnabled = app.sheenChanged.pipe();

--- a/src/main.js
+++ b/src/main.js
@@ -445,26 +445,68 @@ export default async () => {
     const sceneChangedStateObservable = uiModel.scene.pipe(map(() => state));
     uiModel.attachCameraChangeObservable(sceneChangedStateObservable);
 
-    uiModel.orbit.subscribe((orbit) => {
-        if (state.cameraNodeIndex === undefined) {
-            state.userCamera.orbit(orbit.deltaPhi, orbit.deltaTheta);
-        }
-    });
+    // Smooths discrete drag/scroll input deltas into per-frame motion.
+    // Each input delta becomes a short pulse that fades in then out following
+    // easeInOutSine, so motion accelerates and decelerates smoothly instead of
+    // snapping with raw mousemove/wheel timing.
+    const dragSmoother = (() => {
+        let smoothMs = 330;
+        const easeInOutSine = (t) => 0.5 * (1 - Math.cos(Math.PI * t));
+        const orbitPulses = [];
+        const panPulses = [];
+        const zoomPulses = [];
+        const isEnabled = () => state.cameraNodeIndex === undefined;
+        const push = (pulses, a, b) => {
+            if (!isEnabled()) return;
+            pulses.push({ a, b, startTime: performance.now(), appliedA: 0, appliedB: 0 });
+        };
+        const drain = (pulses, applyFn) => {
+            if (pulses.length === 0) return false;
+            const now = performance.now();
+            let netA = 0;
+            let netB = 0;
+            for (let i = pulses.length - 1; i >= 0; i--) {
+                const p = pulses[i];
+                const t = smoothMs > 0 ? Math.min(1, (now - p.startTime) / smoothMs) : 1;
+                const eased = easeInOutSine(t);
+                const targetA = p.a * eased;
+                const targetB = p.b * eased;
+                netA += targetA - p.appliedA;
+                netB += targetB - p.appliedB;
+                p.appliedA = targetA;
+                p.appliedB = targetB;
+                if (t >= 1) pulses.splice(i, 1);
+            }
+            const moved = netA !== 0 || netB !== 0;
+            if (moved) applyFn(netA, netB);
+            return moved || pulses.length > 0;
+        };
+        return {
+            pushOrbit: (dPhi, dTheta) => push(orbitPulses, dPhi, dTheta),
+            pushPan: (dX, dY) => push(panPulses, dX, dY),
+            pushZoom: (dZoom) => push(zoomPulses, dZoom, 0),
+            setSmoothMs: (ms) => { smoothMs = Math.max(0, ms); },
+            tick: () => {
+                const o = drain(orbitPulses, (a, b) => state.userCamera.orbit(a, b));
+                const p = drain(panPulses, (a, b) => state.userCamera.pan(a, b));
+                const z = drain(zoomPulses, (a) => state.userCamera.zoomBy(a));
+                return o || p || z;
+            }
+        };
+    })();
+
+    uiModel.orbit.subscribe((orbit) =>
+        dragSmoother.pushOrbit(orbit.deltaPhi, orbit.deltaTheta)
+    );
     listenForRedraw(uiModel.orbit);
 
-    uiModel.pan.subscribe((pan) => {
-        if (state.cameraNodeIndex === undefined) {
-            state.userCamera.pan(pan.deltaX, -pan.deltaY);
-        }
-    });
+    uiModel.pan.subscribe((pan) => dragSmoother.pushPan(pan.deltaX, -pan.deltaY));
     listenForRedraw(uiModel.pan);
 
-    uiModel.zoom.subscribe((zoom) => {
-        if (state.cameraNodeIndex === undefined) {
-            state.userCamera.zoomBy(zoom.deltaZoom);
-        }
-    });
+    uiModel.zoom.subscribe((zoom) => dragSmoother.pushZoom(zoom.deltaZoom));
     listenForRedraw(uiModel.zoom);
+
+    uiModel.inputSmoothingEnabled.subscribe((enabled) => dragSmoother.setSmoothMs(enabled ? 330 : 0));
 
     listenForRedraw(gltfLoaded);
 
@@ -472,6 +514,8 @@ export default async () => {
     const past = {};
     const update = () => {
         const devicePixelRatio = window.devicePixelRatio || 1;
+
+        redraw |= dragSmoother.tick();
 
         // set the size of the drawingBuffer based on the size it's displayed.
         canvas.width = Math.floor(canvas.clientWidth * devicePixelRatio);

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -14,6 +14,7 @@ const appCreated = createApp({
             debugchannelChanged: new Subject(),
             tonemapChanged: new Subject(),
             skinningChanged: new Subject(),
+            inputSmoothingChanged: new Subject(),
             punctualLightsChanged: new Subject(),
 
             iblChanged: new Subject(),
@@ -103,6 +104,7 @@ const appCreated = createApp({
             exposureSetting: 0,
             toneMap: "Khronos PBR Neutral",
             skinning: true,
+            inputSmoothing: true,
             morphing: true,
             clearcoatEnabled: true,
             sheenEnabled: true,


### PR DESCRIPTION
### Smooth drag/scroll input for camera controls

When interacting with heavier sample models (DamagedHelmet, ABeautifulGame, etc.), camera motion from dragging and scrolling felt jittery. Raw mouse/wheel deltas applied directly to the camera produce visible stutter on less powerful device.

This change buffers each input delta as a short pulse and drains pulses every animation frame using an easeInOutSine curve, so each input event accelerates and decelerates smoothly instead of snapping. Multiple in-flight pulses overlap naturally during a continuous drag, and any remaining pulses keep playing out after the user releases — so the camera glides to a stop instead of cutting off.

Applied uniformly to orbit (rotate), pan, and zoom (wheel, right-drag, pinch). Total accumulated motion is unchanged — userCamera.orbit/pan/zoomBy are additive, so summed partial deltas land at the same final pose; only the timing curve is different.

The 330 ms window was chosen as a middle ground: short enough that input still feels responsive and not laggy, long enough for the easing to be perceptibly smooth across orbit, pan, and zoom. 

**Result: noticeably smoother feel with negligible perceived lag. IridescenceMetallicSphere, IridescenceSuzanne are few good models to observe the change.**